### PR TITLE
Fix the elements discussed in issue #1:

### DIFF
--- a/Masking/dilithium_gadgets.c
+++ b/Masking/dilithium_gadgets.c
@@ -186,7 +186,7 @@ uint64_t portable_128_bit_mul_shift(uint64_t a, uint64_t b, int k){
     uint64_t upper = (hi_lo >> 32) + (cross >> 32)        + hi_hi;
     uint64_t lower = (cross << 32) | (lo_lo & 0xFFFFFFFF);
 
-    return ((upper&((1<<k)-1)) << (64-k)) | (lower >> k);
+    return ((upper&(((uint64_t)1<<k)-1)) << (64-k)) | (lower >> k);
 
 
 }

--- a/Masking/dilithium_gadgets.h
+++ b/Masking/dilithium_gadgets.h
@@ -65,11 +65,15 @@
 #define int128_t __int128_t
 #endif
 
+void ZeroEncoding(uint32_t *x, int q, int n);
+void RefreshQuasiLin(uint32_t *x, int q, int n);
+void ZeroEncoding64(uint64_t *x, int q, int n);
+void RefreshQuasiLin64(uint64_t *x, int q, int n);
 
 void securediv(uint32_t* x, uint32_t* y, int log_alpha, int inv_alpha, int q, int n);
 
 void generic_shift(uint32_t* x, uint32_t* y, int k, int q, int n);
-
+void generic_shift64(uint64_t* x, uint64_t* y, int k, uint64_t q, int n);
 
 void reject_sampling(uint32_t* x, uint32_t* z, int mode, int q, int n);
 int single_coeff_reject(uint32_t* x, int mode, int q, int n);

--- a/Masking/dilithium_gadgets.h
+++ b/Masking/dilithium_gadgets.h
@@ -67,8 +67,8 @@
 
 void ZeroEncoding(uint32_t *x, int q, int n);
 void RefreshQuasiLin(uint32_t *x, int q, int n);
-void ZeroEncoding64(uint64_t *x, int q, int n);
-void RefreshQuasiLin64(uint64_t *x, int q, int n);
+void ZeroEncoding64(uint64_t *x, uint64_t q, int n);
+void RefreshQuasiLin64(uint64_t *x, uint64_t q, int n);
 
 void securediv(uint32_t* x, uint32_t* y, int log_alpha, int inv_alpha, int q, int n);
 

--- a/Masking/fastdilithium_gadgets.c
+++ b/Masking/fastdilithium_gadgets.c
@@ -54,7 +54,7 @@ void RefreshQuasiLin(uint32_t *x, int q, int n)
     }
 }
 
-void ZeroEncoding64(uint64_t *x, int q, int n)
+void ZeroEncoding64(uint64_t *x, uint64_t q, int n)
 {
     if(n == 1){
         x[0] = 0;
@@ -75,7 +75,7 @@ void ZeroEncoding64(uint64_t *x, int q, int n)
     }
 }
 
-void RefreshQuasiLin64(uint64_t *x, int q, int n)
+void RefreshQuasiLin64(uint64_t *x, uint64_t q, int n)
 {
     uint64_t y[n];
     ZeroEncoding64(y, q, n);
@@ -149,7 +149,7 @@ void LMSwitch(uint32_t* x, uint32_t* y, int q, int rho, int n){
   //refreshArithModp(delta, 1<<rho, n);
   RefreshQuasiLin(delta, 1<<rho, n);
 
-  for(int i=0; i < n; ++i) y[i] = ((uint64_t)x[i] + (uint64_t)((q<<rho) - q*delta[i]))%(uint64_t)(q<<rho);
+  for(int i=0; i < n; ++i) y[i] = ((uint64_t)x[i] + (uint64_t)(((uint64_t)q<<rho) - q*delta[i]))%(uint64_t)((uint64_t)q<<rho);
 
   
 }


### PR DESCRIPTION
- Fix some value negation modulo q

- Fix Dilithium mode `3` (ML-DSA-65) that had various integers overflows because of the larger value of `RHO`.